### PR TITLE
feat(Serialize): add information to errors for tracing data types

### DIFF
--- a/src/lib/Serialize.ts
+++ b/src/lib/Serialize.ts
@@ -46,7 +46,7 @@ export namespace Serialize {
       return { [Keying.Type]: Type.Set, [Keying.Value]: toJsonCompatibleArray(Array.from(data)) };
     }
 
-    throw new TypeError(`Serialize received an unknown type while formatting: "${data.constructor.name}".`);
+    throw new TypeError(`Serialize.toJsonCompatible() received an unknown type while formatting: "${data.constructor.name}".`);
   }
 
   function toJsonCompatibleArray(array: unknown[]): JsonCompatible[] {
@@ -132,7 +132,7 @@ export namespace Serialize {
         return undefined;
 
       default:
-        throw new TypeError('Serialize received an unknown type.');
+        throw new TypeError(`Serialize.fromJsonCompatible() received an unknown type while parsing: "${value}" (${type}).`);
     }
   }
 

--- a/tests/lib/Serialize.test.ts
+++ b/tests/lib/Serialize.test.ts
@@ -426,7 +426,7 @@ describe('Serialize', () => {
 
     test('GIVEN unknown type THEN throws error', () => {
       expect(() => Serialize.toJsonCompatible(() => true)).toThrowError(
-        new TypeError('Serialize received an unknown type while formatting: "Function".')
+        new TypeError('Serialize.toJsonCompatible() received an unknown type while formatting: "Function".')
       );
     });
   });
@@ -936,7 +936,9 @@ describe('Serialize', () => {
 
     test('GIVEN unknown type THEN throws error', () => {
       // @ts-expect-error 2322 - Type 'function' is not assignable to type 'Serialize.Type'.
-      expect(() => Serialize.fromJsonCompatible({ [Serialize.Keying.Type]: 'function' })).toThrowError('Serialize received an unknown type.');
+      expect(() => Serialize.fromJsonCompatible({ [Serialize.Keying.Type]: 'function' })).toThrowError(
+        'Serialize.fromJsonCompatible() received an unknown type while parsing: "undefined" (function).'
+      );
     });
   });
 });


### PR DESCRIPTION
This pull request adds more information about what data and data type was being transformed to or from json compatibility.